### PR TITLE
할 일 하나를 수정할 수 있다

### DIFF
--- a/src/main/java/kr/rogarithm/todos/domain/todo/controller/TodoController.java
+++ b/src/main/java/kr/rogarithm/todos/domain/todo/controller/TodoController.java
@@ -3,12 +3,14 @@ package kr.rogarithm.todos.domain.todo.controller;
 import java.util.List;
 import kr.rogarithm.todos.domain.todo.dto.AddTodoRequest;
 import kr.rogarithm.todos.domain.todo.dto.TodoResponse;
+import kr.rogarithm.todos.domain.todo.dto.UpdateTodoRequest;
 import kr.rogarithm.todos.domain.todo.service.TodoService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -44,6 +46,13 @@ public class TodoController {
     public ResponseEntity<Void> addTodo(@RequestBody AddTodoRequest addTodoRequest) {
 
         todoService.saveTodo(addTodoRequest);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PutMapping("")
+    public ResponseEntity<Void> updateTodo(@RequestBody UpdateTodoRequest updateTodoRequest) {
+
+        todoService.updateTodo(updateTodoRequest);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/kr/rogarithm/todos/domain/todo/dao/TodoMapper.java
+++ b/src/main/java/kr/rogarithm/todos/domain/todo/dao/TodoMapper.java
@@ -13,5 +13,7 @@ public interface TodoMapper {
 
     int insertTodo(Todo todo);
 
+    int updateTodo(Todo todo);
+
     void deleteTodoByNameAndDescription(String name, String description);
 }

--- a/src/main/java/kr/rogarithm/todos/domain/todo/dao/TodoMapper.java
+++ b/src/main/java/kr/rogarithm/todos/domain/todo/dao/TodoMapper.java
@@ -15,5 +15,5 @@ public interface TodoMapper {
 
     int updateTodo(Todo todo);
 
-    void deleteTodoByNameAndDescription(String name, String description);
+    void deleteAllTodos();
 }

--- a/src/main/java/kr/rogarithm/todos/domain/todo/dto/UpdateTodoRequest.java
+++ b/src/main/java/kr/rogarithm/todos/domain/todo/dto/UpdateTodoRequest.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
+import kr.rogarithm.todos.domain.todo.domain.Todo;
 import lombok.Getter;
 
 @Getter
@@ -16,6 +17,16 @@ public class UpdateTodoRequest {
     private String description;
     @Pattern(regexp = "ALL|INCOMPLETE|COMPLETE")
     private String state;
+
+    public Todo toTodo() {
+
+        return Todo.builder()
+                   .id(this.id)
+                   .name(this.name)
+                   .description(this.description)
+                   .state(this.state)
+                   .build();
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/kr/rogarithm/todos/domain/todo/dto/UpdateTodoRequest.java
+++ b/src/main/java/kr/rogarithm/todos/domain/todo/dto/UpdateTodoRequest.java
@@ -1,0 +1,37 @@
+package kr.rogarithm.todos.domain.todo.dto;
+
+import java.util.Objects;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class UpdateTodoRequest {
+
+    @Min(1L)
+    private Long id;
+    @NotBlank(message = "할일 제목이 입력되지 않았습니다")
+    private String name;
+    private String description;
+    @Pattern(regexp = "ALL|INCOMPLETE|COMPLETE")
+    private String state;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UpdateTodoRequest that = (UpdateTodoRequest) o;
+        return id.equals(that.id) && name.equals(that.name) && Objects.equals(description, that.description)
+                && state.equals(that.state);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, description, state);
+    }
+}

--- a/src/main/java/kr/rogarithm/todos/domain/todo/service/TodoService.java
+++ b/src/main/java/kr/rogarithm/todos/domain/todo/service/TodoService.java
@@ -9,6 +9,7 @@ import kr.rogarithm.todos.domain.todo.dao.TodoMapper;
 import kr.rogarithm.todos.domain.todo.domain.Todo;
 import kr.rogarithm.todos.domain.todo.dto.AddTodoRequest;
 import kr.rogarithm.todos.domain.todo.dto.TodoResponse;
+import kr.rogarithm.todos.domain.todo.dto.UpdateTodoRequest;
 import kr.rogarithm.todos.domain.todo.exception.TodoItemNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
@@ -46,5 +47,8 @@ public class TodoService {
     public void saveTodo(@Valid AddTodoRequest addTodoRequest) {
 
         todoMapper.insertTodo(addTodoRequest.toTodo());
+    }
+
+    public void updateTodo(@Valid UpdateTodoRequest updateTodoRequest) {
     }
 }

--- a/src/main/java/kr/rogarithm/todos/domain/todo/service/TodoService.java
+++ b/src/main/java/kr/rogarithm/todos/domain/todo/service/TodoService.java
@@ -50,5 +50,14 @@ public class TodoService {
     }
 
     public void updateTodo(@Valid UpdateTodoRequest updateTodoRequest) {
+
+        Long todoId = updateTodoRequest.getId();
+        Todo todo = todoMapper.selectTodoById(todoId);
+
+        if (todo == null) {
+            throw new TodoItemNotFoundException("입력한 아이디 " + todoId + "로 등록된 할 일 항목이 없어 수정이 불가합니다");
+        }
+
+        todoMapper.updateTodo(updateTodoRequest.toTodo());
     }
 }

--- a/src/main/java/kr/rogarithm/todos/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/rogarithm/todos/global/exception/GlobalExceptionHandler.java
@@ -23,6 +23,11 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<Map<String, String>> constraintViolationException(ConstraintViolationException e) {
 
         Map<String, String> errors = new HashMap<>();
+
+        if (e.getConstraintViolations() == null) {
+            return ResponseEntity.badRequest().build();
+        }
+
         for (ConstraintViolation<?> violation : e.getConstraintViolations()) {
             errors.put(violation.getRootBeanClass().getName(), violation.getMessage());
          }

--- a/src/main/java/kr/rogarithm/todos/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/rogarithm/todos/global/exception/GlobalExceptionHandler.java
@@ -31,29 +31,29 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(TodoItemNotFoundException.class)
-    protected ResponseEntity<Void> todoItemNotFoundException(TodoItemNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    protected ResponseEntity<String> todoItemNotFoundException(TodoItemNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
 
     @ExceptionHandler(DuplicateAccountException.class)
-    protected ResponseEntity<Void> duplicateAccountException(DuplicateAccountException e) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    protected ResponseEntity<String> duplicateAccountException(DuplicateAccountException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
     }
 
     @ExceptionHandler(DuplicateNicknameException.class)
-    protected ResponseEntity<Void> duplicateNicknameException(DuplicateNicknameException e) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    protected ResponseEntity<String> duplicateNicknameException(DuplicateNicknameException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
     }
 
     @ExceptionHandler(InvalidCompanyRegistrationNumberException.class)
-    protected ResponseEntity<Void> invalidCompanyRegistrationNumberException(
+    protected ResponseEntity<String> invalidCompanyRegistrationNumberException(
             InvalidCompanyRegistrationNumberException e) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
     }
 
     @ExceptionHandler(AuthenticationFailedException.class)
-    protected ResponseEntity<Void> authenticationFailedException(AuthenticationFailedException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    protected ResponseEntity<String> authenticationFailedException(AuthenticationFailedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
     }
 
     @ExceptionHandler(VerificationException.class)

--- a/src/main/java/kr/rogarithm/todos/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/rogarithm/todos/global/exception/GlobalExceptionHandler.java
@@ -25,7 +25,7 @@ public class GlobalExceptionHandler {
         Map<String, String> errors = new HashMap<>();
         for (ConstraintViolation<?> violation : e.getConstraintViolations()) {
             errors.put(violation.getRootBeanClass().getName(), violation.getMessage());
-         }
+        }
 
         return ResponseEntity.badRequest().body(errors);
     }

--- a/src/main/java/kr/rogarithm/todos/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/rogarithm/todos/global/exception/GlobalExceptionHandler.java
@@ -23,11 +23,6 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<Map<String, String>> constraintViolationException(ConstraintViolationException e) {
 
         Map<String, String> errors = new HashMap<>();
-
-        if (e.getConstraintViolations() == null) {
-            return ResponseEntity.badRequest().build();
-        }
-
         for (ConstraintViolation<?> violation : e.getConstraintViolations()) {
             errors.put(violation.getRootBeanClass().getName(), violation.getMessage());
          }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,9 +1,2 @@
-INSERT INTO `todo` (`name`, `description`, `state`)
-VALUES ('콜라 사기', '집 앞 슈퍼에서 콜라 사오기', 'INCOMPLETE');
-INSERT INTO `todo` (`name`, `description`, `state`)
-VALUES ('커피 원두 구입', '디벨로핑룸 가서 커피 원두 사기', 'COMPLETE');
-INSERT INTO `todo` (`name`, `description`, `state`)
-VALUES ('회덮밥 사오기', '바다회 사랑 가서 회덮밥 포장해오기', 'INCOMPLETE');
-
 INSERT INTO `user` (`account`, `password`, `nickname`, `phone`, `crn`)
 VALUES ('sehoongim', 'q1w2e3!', 'shrimp-cracker', '010-1010-1010', '123-45-67890');

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,2 +1,8 @@
+INSERT INTO `todo` (`name`, `description`, `state`)
+VALUES ('콜라 사기', '집 앞 슈퍼에서 콜라 사오기', 'INCOMPLETE');
+INSERT INTO `todo` (`name`, `description`, `state`)
+VALUES ('커피 원두 구입', '디벨로핑룸 가서 커피 원두 사기', 'COMPLETE');
+INSERT INTO `todo` (`name`, `description`, `state`)
+VALUES ('회덮밥 사오기', '바다회 사랑 가서 회덮밥 포장해오기', 'INCOMPLETE');
 INSERT INTO `user` (`account`, `password`, `nickname`, `phone`, `crn`)
 VALUES ('sehoongim', 'q1w2e3!', 'shrimp-cracker', '010-1010-1010', '123-45-67890');

--- a/src/main/resources/mybatis/mapper/TodoMapper.xml
+++ b/src/main/resources/mybatis/mapper/TodoMapper.xml
@@ -32,10 +32,16 @@
     (#{name}, #{description}, #{state})
   </insert>
 
-  <delete id="deleteTodoByNameAndDescription">
+  <insert id="updateTodo" parameterType="kr.rogarithm.todos.domain.todo.domain.Todo">
+    UPDATE todo
+    SET name = #{name},
+    description = #{description},
+    state = #{state}
+    WHERE id = #{id}
+  </insert>
+
+  <delete id="deleteAllTodos">
     DELETE FROM todo
-    WHERE name = #{name}
-    AND description = #{description}
   </delete>
 
 </mapper>

--- a/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
@@ -1,7 +1,6 @@
 package kr.rogarithm.todos.domain.todo.controller;
 
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -13,7 +12,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
-import javax.validation.ConstraintViolationException;
 import kr.rogarithm.todos.domain.todo.domain.Todo;
 import kr.rogarithm.todos.domain.todo.dto.AddTodoRequest;
 import kr.rogarithm.todos.domain.todo.dto.TodoResponse;
@@ -230,26 +228,6 @@ class TodoControllerTest {
                        .accept(MediaType.APPLICATION_JSON))
                .andDo(print())
                .andExpect(status().isOk());
-
-        verify(todoService).updateTodo(updateTodoRequest);
-    }
-
-    @Test
-    public void updateTodoFailWhenInvalidRequest() throws Exception {
-
-        //given
-        String content = objectMapper.writeValueAsString(updateTodoRequest);
-
-        //when
-        doThrow(new ConstraintViolationException("invalid", null)).when(todoService).updateTodo(updateTodoRequest);
-
-        //then
-        mockMvc.perform(put("/todo")
-                       .content(content)
-                       .contentType(MediaType.APPLICATION_JSON)
-                       .accept(MediaType.APPLICATION_JSON))
-               .andDo(print())
-               .andExpect(status().isBadRequest());
 
         verify(todoService).updateTodo(updateTodoRequest);
     }

--- a/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -15,6 +16,7 @@ import java.util.List;
 import kr.rogarithm.todos.domain.todo.domain.Todo;
 import kr.rogarithm.todos.domain.todo.dto.AddTodoRequest;
 import kr.rogarithm.todos.domain.todo.dto.TodoResponse;
+import kr.rogarithm.todos.domain.todo.dto.UpdateTodoRequest;
 import kr.rogarithm.todos.domain.todo.exception.TodoItemNotFoundException;
 import kr.rogarithm.todos.domain.todo.service.TodoService;
 import org.jeasy.random.EasyRandom;
@@ -46,6 +48,8 @@ class TodoControllerTest {
 
     AddTodoRequest addTodoRequest;
 
+    UpdateTodoRequest updateTodoRequest;
+
     Long id;
 
     Todo todo;
@@ -54,6 +58,7 @@ class TodoControllerTest {
     public void setUp() {
         generator = new EasyRandom();
         addTodoRequest = generator.nextObject(AddTodoRequest.class);
+        updateTodoRequest = generator.nextObject(UpdateTodoRequest.class);
         id = generator.nextObject(Long.class);
         todo = generator.nextObject(Todo.class);
     }
@@ -206,5 +211,25 @@ class TodoControllerTest {
                .andExpect(status().isOk());
 
         verify(todoService).getTodos(state, size);
+    }
+
+    @Test
+    public void updateTodoSuccessWhenValidRequest() throws Exception {
+
+        //given
+        String content = objectMapper.writeValueAsString(updateTodoRequest);
+
+        //when
+        doNothing().when(todoService).updateTodo(updateTodoRequest);
+
+        //then
+        mockMvc.perform(put("/todo")
+                       .content(content)
+                       .contentType(MediaType.APPLICATION_JSON)
+                       .accept(MediaType.APPLICATION_JSON))
+               .andDo(print())
+               .andExpect(status().isOk());
+
+        verify(todoService).updateTodo(updateTodoRequest);
     }
 }

--- a/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
@@ -1,6 +1,7 @@
 package kr.rogarithm.todos.domain.todo.controller;
 
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -20,6 +21,7 @@ import kr.rogarithm.todos.domain.todo.exception.TodoItemNotFoundException;
 import kr.rogarithm.todos.domain.todo.service.TodoService;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -213,6 +215,7 @@ class TodoControllerTest {
     }
 
     @Test
+    @DisplayName("할 일 업데이트 성공")
     public void updateTodoSuccessWhenValidRequest() throws Exception {
 
         //given
@@ -228,6 +231,27 @@ class TodoControllerTest {
                        .accept(MediaType.APPLICATION_JSON))
                .andDo(print())
                .andExpect(status().isOk());
+
+        verify(todoService).updateTodo(updateTodoRequest);
+    }
+
+    @Test
+    @DisplayName("전에 등록했던 할 일이 아니라면 업데이트에 실패")
+    public void updateTodoFailWhenTodoNotAddedBefore() throws Exception {
+
+        //given
+        String content = objectMapper.writeValueAsString(updateTodoRequest);
+
+        //when
+        doThrow(TodoItemNotFoundException.class).when(todoService).updateTodo(updateTodoRequest);
+
+        //then
+        mockMvc.perform(put("/todo")
+                       .content(content)
+                       .contentType(MediaType.APPLICATION_JSON)
+                       .accept(MediaType.APPLICATION_JSON))
+               .andDo(print())
+               .andExpect(status().isNotFound());
 
         verify(todoService).updateTodo(updateTodoRequest);
     }

--- a/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
@@ -1,6 +1,7 @@
 package kr.rogarithm.todos.domain.todo.controller;
 
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -12,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import javax.validation.ConstraintViolationException;
 import kr.rogarithm.todos.domain.todo.domain.Todo;
 import kr.rogarithm.todos.domain.todo.dto.AddTodoRequest;
 import kr.rogarithm.todos.domain.todo.dto.TodoResponse;
@@ -228,6 +230,26 @@ class TodoControllerTest {
                        .accept(MediaType.APPLICATION_JSON))
                .andDo(print())
                .andExpect(status().isOk());
+
+        verify(todoService).updateTodo(updateTodoRequest);
+    }
+
+    @Test
+    public void updateTodoFailWhenInvalidRequest() throws Exception {
+
+        //given
+        String content = objectMapper.writeValueAsString(updateTodoRequest);
+
+        //when
+        doThrow(new ConstraintViolationException("invalid", null)).when(todoService).updateTodo(updateTodoRequest);
+
+        //then
+        mockMvc.perform(put("/todo")
+                       .content(content)
+                       .contentType(MediaType.APPLICATION_JSON)
+                       .accept(MediaType.APPLICATION_JSON))
+               .andDo(print())
+               .andExpect(status().isBadRequest());
 
         verify(todoService).updateTodo(updateTodoRequest);
     }

--- a/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
@@ -1,6 +1,5 @@
 package kr.rogarithm.todos.domain.todo.controller;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -98,7 +97,7 @@ class TodoControllerTest {
         String content = objectMapper.writeValueAsString(addTodoRequest);
 
         //when
-        doNothing().when(todoService).saveTodo(eq(addTodoRequest));
+        doNothing().when(todoService).saveTodo(addTodoRequest);
 
         //then
         mockMvc.perform(post("/todo")
@@ -108,7 +107,7 @@ class TodoControllerTest {
                .andDo(print())
                .andExpect(status().isOk());
 
-        verify(todoService).saveTodo(eq(addTodoRequest));
+        verify(todoService).saveTodo(addTodoRequest);
     }
 
     @Test

--- a/src/test/java/kr/rogarithm/todos/domain/todo/dao/TodoMapperTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/dao/TodoMapperTest.java
@@ -17,7 +17,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
 
+@Sql({"/schema.sql"})
 @SpringBootTest
 class TodoMapperTest {
 
@@ -137,8 +139,6 @@ class TodoMapperTest {
                          .build();
 
         int affected = todoMapper.updateTodo(todo2);
-
-        assertThat(todo.getId()).isEqualTo(todo2.getId());
         assertThat(affected).isEqualTo(1);
     }
 }

--- a/src/test/java/kr/rogarithm/todos/domain/todo/dao/TodoMapperTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/dao/TodoMapperTest.java
@@ -80,7 +80,7 @@ class TodoMapperTest {
     public void selectAllTodos() {
 
         int size = 0;
-        for (int i=0; i<10; i++) {
+        for (int i = 0; i < 10; i++) {
             Todo todo = generator.nextObject(Todo.class);
             todoMapper.insertTodo(todo);
             size++;
@@ -97,10 +97,12 @@ class TodoMapperTest {
         int size = 0;
         String state = "COMPLETE";
 
-        for (int i=0; i<10; i++) {
+        for (int i = 0; i < 10; i++) {
             Todo todo = generator.nextObject(Todo.class);
             todoMapper.insertTodo(todo);
-            if (todo.getState().equals(state)) size++;
+            if (todo.getState().equals(state)) {
+                size++;
+            }
         }
 
         List<Todo> todos = todoMapper.selectTodos(state, (long) size);
@@ -113,10 +115,12 @@ class TodoMapperTest {
         int size = 0;
         String state = "INCOMPLETE";
 
-        for (int i=0; i<10; i++) {
+        for (int i = 0; i < 10; i++) {
             Todo todo = generator.nextObject(Todo.class);
             todoMapper.insertTodo(todo);
-            if (todo.getState().equals(state)) size++;
+            if (todo.getState().equals(state)) {
+                size++;
+            }
         }
 
         List<Todo> todos = todoMapper.selectTodos(state, (long) size);

--- a/src/test/java/kr/rogarithm/todos/domain/todo/dao/TodoMapperTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/dao/TodoMapperTest.java
@@ -26,10 +26,6 @@ class TodoMapperTest {
 
     EasyRandom generator;
 
-    Long size;
-
-    List<Todo> todos;
-
     @BeforeEach
     public void setUp() {
 

--- a/src/test/java/kr/rogarithm/todos/domain/todo/end2end/TodoEnd2EndTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/end2end/TodoEnd2EndTest.java
@@ -1,15 +1,24 @@
 package kr.rogarithm.todos.domain.todo.end2end;
 
+import static kr.rogarithm.todos.domain.todo.fixture.UpdateTodoParam.ID;
+import static kr.rogarithm.todos.domain.todo.fixture.UpdateTodoParam.IS_VALID_STATE;
+import static kr.rogarithm.todos.domain.todo.fixture.UpdateTodoParam.STATE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import kr.rogarithm.todos.domain.todo.dto.AddTodoRequest;
+import kr.rogarithm.todos.domain.todo.dto.UpdateTodoRequest;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.jdbc.Sql;
 
+@Sql({"/schema.sql", "/data.sql"})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class TodoEnd2EndTest {
 
@@ -133,4 +142,36 @@ public class TodoEnd2EndTest {
                 .log().all()
                 .extract();
     }
+
+    @DisplayName("할 일 수정 요청 성공")
+    @Test
+    public void updateTodoSuccess() {
+
+        RestAssured.port = port;
+
+        EasyRandomParameters updateTodoParam = new EasyRandomParameters()
+                .randomize(ID, () -> 1L)
+                .randomize(STATE, IS_VALID_STATE);
+        EasyRandom generator = new EasyRandom(updateTodoParam);
+
+        UpdateTodoRequest request = generator.nextObject(UpdateTodoRequest.class);
+
+        ExtractableResponse<Response> response = updateTodo(request);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    public static ExtractableResponse<Response> updateTodo(UpdateTodoRequest updateTodoRequest) {
+
+        return RestAssured
+                .given().log().all()
+                .contentType("application/json")
+                .body(updateTodoRequest)
+                .when()
+                .put("/todo")
+                .then()
+                .log().all()
+                .extract();
+    }
+
 }

--- a/src/test/java/kr/rogarithm/todos/domain/todo/end2end/TodoEnd2EndTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/end2end/TodoEnd2EndTest.java
@@ -31,9 +31,9 @@ public class TodoEnd2EndTest {
         RestAssured.port = port;
 
         AddTodoRequest requestViolatesConstraint = AddTodoRequest.builder()
-                                                      .name("")
-                                                      .description("물 사러 갔다오기")
-                                                      .build();
+                                                                 .name("")
+                                                                 .description("물 사러 갔다오기")
+                                                                 .build();
 
         ExtractableResponse<Response> response = addTodo(requestViolatesConstraint);
 

--- a/src/test/java/kr/rogarithm/todos/domain/todo/fixture/UpdateTodoParam.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/fixture/UpdateTodoParam.java
@@ -1,0 +1,30 @@
+package kr.rogarithm.todos.domain.todo.fixture;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Predicate;
+import kr.rogarithm.todos.domain.todo.dto.UpdateTodoRequest;
+import org.jeasy.random.FieldPredicates;
+import org.jeasy.random.api.Randomizer;
+import org.jeasy.random.randomizers.range.LongRangeRandomizer;
+import org.jeasy.random.randomizers.text.StringRandomizer;
+
+public class UpdateTodoParam {
+
+    public static final Predicate<Field> ID = FieldPredicates.named("id")
+                                                      .and(FieldPredicates.ofType(Long.class))
+                                                      .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+    public static final Predicate<Field> STATE = FieldPredicates.named("state")
+                                                         .and(FieldPredicates.ofType(String.class))
+                                                         .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+    public static final Predicate<Field> NAME = FieldPredicates.named("name")
+                                                        .and(FieldPredicates.ofType(String.class))
+                                                        .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+
+    public static final LongRangeRandomizer IS_VALID_ID = new LongRangeRandomizer(1L, 100L);
+    public static final LongRangeRandomizer IS_INVALID_ID = new LongRangeRandomizer(-100L, 0L);
+    public static final Randomizer<String> IS_VALID_STATE = () -> List.of("INCOMPLETE", "COMPLETE").get(new Random().nextInt(1));
+    public static final Randomizer<String> IS_INVALID_STATE = new StringRandomizer();
+    public static final Randomizer<String> IS_INVALID_NAME = () -> "";
+}

--- a/src/test/java/kr/rogarithm/todos/domain/todo/fixture/UpdateTodoParam.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/fixture/UpdateTodoParam.java
@@ -13,18 +13,19 @@ import org.jeasy.random.randomizers.text.StringRandomizer;
 public class UpdateTodoParam {
 
     public static final Predicate<Field> ID = FieldPredicates.named("id")
-                                                      .and(FieldPredicates.ofType(Long.class))
-                                                      .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+                                                             .and(FieldPredicates.ofType(Long.class))
+                                                             .and(FieldPredicates.inClass(UpdateTodoRequest.class));
     public static final Predicate<Field> STATE = FieldPredicates.named("state")
-                                                         .and(FieldPredicates.ofType(String.class))
-                                                         .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+                                                                .and(FieldPredicates.ofType(String.class))
+                                                                .and(FieldPredicates.inClass(UpdateTodoRequest.class));
     public static final Predicate<Field> NAME = FieldPredicates.named("name")
-                                                        .and(FieldPredicates.ofType(String.class))
-                                                        .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+                                                               .and(FieldPredicates.ofType(String.class))
+                                                               .and(FieldPredicates.inClass(UpdateTodoRequest.class));
 
     public static final LongRangeRandomizer IS_VALID_ID = new LongRangeRandomizer(1L, 100L);
     public static final LongRangeRandomizer IS_INVALID_ID = new LongRangeRandomizer(-100L, 0L);
-    public static final Randomizer<String> IS_VALID_STATE = () -> List.of("INCOMPLETE", "COMPLETE").get(new Random().nextInt(1));
+    public static final Randomizer<String> IS_VALID_STATE = () -> List.of("INCOMPLETE", "COMPLETE").get(
+            new Random().nextInt(1));
     public static final Randomizer<String> IS_INVALID_STATE = new StringRandomizer();
     public static final Randomizer<String> IS_INVALID_NAME = () -> "";
 }

--- a/src/test/java/kr/rogarithm/todos/domain/todo/integration/TodoIntegrationTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/integration/TodoIntegrationTest.java
@@ -66,8 +66,8 @@ public class TodoIntegrationTest {
     public void addTodoFailWhenRequestNotSatisfyConstraint() {
 
         Predicate<Field> name = FieldPredicates.named("name")
-                                                 .and(FieldPredicates.ofType(String.class))
-                                                 .and(FieldPredicates.inClass(AddTodoRequest.class));
+                                               .and(FieldPredicates.ofType(String.class))
+                                               .and(FieldPredicates.inClass(AddTodoRequest.class));
         EasyRandomParameters invalidName = new EasyRandomParameters().randomize(name, () -> "");
 
         EasyRandom generator = new EasyRandom(invalidName);
@@ -117,7 +117,8 @@ public class TodoIntegrationTest {
                 .randomize(STATE, IS_VALID_STATE);
 
         EasyRandom generator = new EasyRandom(todoParameters);
-        assertThrows(ConstraintViolationException.class, () -> todoController.updateTodo(generator.nextObject(UpdateTodoRequest.class)));
+        assertThrows(ConstraintViolationException.class,
+                () -> todoController.updateTodo(generator.nextObject(UpdateTodoRequest.class)));
     }
 
     @DisplayName("name 필드가 유효하지 않은 할 일 수정 요청 시 실패")
@@ -130,7 +131,8 @@ public class TodoIntegrationTest {
                 .randomize(STATE, IS_VALID_STATE);
 
         EasyRandom generator = new EasyRandom(todoParameters);
-        assertThrows(ConstraintViolationException.class, () -> todoController.updateTodo(generator.nextObject(UpdateTodoRequest.class)));
+        assertThrows(ConstraintViolationException.class,
+                () -> todoController.updateTodo(generator.nextObject(UpdateTodoRequest.class)));
     }
 
     @DisplayName("state 필드가 유효하지 않은 할 일 수정 요청 시 실패")
@@ -142,6 +144,7 @@ public class TodoIntegrationTest {
                 .randomize(STATE, IS_INVALID_STATE);
 
         EasyRandom generator = new EasyRandom(todoParameters);
-        assertThrows(ConstraintViolationException.class, () -> todoController.updateTodo(generator.nextObject(UpdateTodoRequest.class)));
+        assertThrows(ConstraintViolationException.class,
+                () -> todoController.updateTodo(generator.nextObject(UpdateTodoRequest.class)));
     }
 }

--- a/src/test/java/kr/rogarithm/todos/domain/todo/integration/TodoIntegrationTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/integration/TodoIntegrationTest.java
@@ -1,10 +1,17 @@
 package kr.rogarithm.todos.domain.todo.integration;
 
+import static kr.rogarithm.todos.domain.todo.fixture.UpdateTodoParam.ID;
+import static kr.rogarithm.todos.domain.todo.fixture.UpdateTodoParam.IS_INVALID_ID;
+import static kr.rogarithm.todos.domain.todo.fixture.UpdateTodoParam.IS_INVALID_NAME;
+import static kr.rogarithm.todos.domain.todo.fixture.UpdateTodoParam.IS_INVALID_STATE;
+import static kr.rogarithm.todos.domain.todo.fixture.UpdateTodoParam.IS_VALID_ID;
+import static kr.rogarithm.todos.domain.todo.fixture.UpdateTodoParam.IS_VALID_STATE;
+import static kr.rogarithm.todos.domain.todo.fixture.UpdateTodoParam.NAME;
+import static kr.rogarithm.todos.domain.todo.fixture.UpdateTodoParam.STATE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Field;
 import java.util.List;
-import java.util.Random;
 import java.util.function.Predicate;
 import javax.validation.ConstraintViolationException;
 import kr.rogarithm.todos.domain.todo.controller.TodoController;
@@ -13,8 +20,6 @@ import kr.rogarithm.todos.domain.todo.dto.UpdateTodoRequest;
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 import org.jeasy.random.FieldPredicates;
-import org.jeasy.random.randomizers.range.LongRangeRandomizer;
-import org.jeasy.random.randomizers.text.StringRandomizer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,19 +81,9 @@ public class TodoIntegrationTest {
     @Test
     public void updateTodoFailWhenInvalidIdParameter() {
 
-        Predicate<Field> updateId = FieldPredicates.named("id")
-                                                   .and(FieldPredicates.ofType(Long.class))
-                                                   .and(FieldPredicates.inClass(UpdateTodoRequest.class));
-        Predicate<Field> updateState = FieldPredicates.named("state")
-                                                      .and(FieldPredicates.ofType(String.class))
-                                                      .and(FieldPredicates.inClass(UpdateTodoRequest.class));
-        Predicate<Field> updateName = FieldPredicates.named("name")
-                                                     .and(FieldPredicates.ofType(String.class))
-                                                     .and(FieldPredicates.inClass(UpdateTodoRequest.class));
-
         EasyRandomParameters todoParameters = new EasyRandomParameters()
-                .randomize(updateId, new LongRangeRandomizer(-100L, 0L))
-                .randomize(updateState, () -> List.of("INCOMPLETE", "COMPLETE").get(new Random().nextInt(1)));
+                .randomize(ID, IS_INVALID_ID)
+                .randomize(STATE, IS_VALID_STATE);
 
         EasyRandom generator = new EasyRandom(todoParameters);
         assertThrows(ConstraintViolationException.class, () -> todoController.updateTodo(generator.nextObject(UpdateTodoRequest.class)));
@@ -98,20 +93,10 @@ public class TodoIntegrationTest {
     @Test
     public void updateTodoFailWhenInvalidParameter() {
 
-        Predicate<Field> updateId = FieldPredicates.named("id")
-                                                   .and(FieldPredicates.ofType(Long.class))
-                                                   .and(FieldPredicates.inClass(UpdateTodoRequest.class));
-        Predicate<Field> updateState = FieldPredicates.named("state")
-                                                      .and(FieldPredicates.ofType(String.class))
-                                                      .and(FieldPredicates.inClass(UpdateTodoRequest.class));
-        Predicate<Field> updateName = FieldPredicates.named("name")
-                                                     .and(FieldPredicates.ofType(String.class))
-                                                     .and(FieldPredicates.inClass(UpdateTodoRequest.class));
-
         EasyRandomParameters todoParameters = new EasyRandomParameters()
-                .randomize(updateId, new LongRangeRandomizer(1L, 100L))
-                .randomize(updateName, () -> "")
-                .randomize(updateState, () -> List.of("INCOMPLETE", "COMPLETE").get(new Random().nextInt(1)));
+                .randomize(ID, IS_VALID_ID)
+                .randomize(NAME, IS_INVALID_NAME)
+                .randomize(STATE, IS_VALID_STATE);
 
         EasyRandom generator = new EasyRandom(todoParameters);
         assertThrows(ConstraintViolationException.class, () -> todoController.updateTodo(generator.nextObject(UpdateTodoRequest.class)));
@@ -121,22 +106,11 @@ public class TodoIntegrationTest {
     @Test
     public void updateTodoFailWhenInvalidStateParameter() {
 
-        Predicate<Field> updateId = FieldPredicates.named("id")
-                                                 .and(FieldPredicates.ofType(Long.class))
-                                                 .and(FieldPredicates.inClass(UpdateTodoRequest.class));
-        Predicate<Field> updateState = FieldPredicates.named("state")
-                                                    .and(FieldPredicates.ofType(String.class))
-                                                    .and(FieldPredicates.inClass(UpdateTodoRequest.class));
-        Predicate<Field> updateName = FieldPredicates.named("name")
-                                                    .and(FieldPredicates.ofType(String.class))
-                                                    .and(FieldPredicates.inClass(UpdateTodoRequest.class));
-
         EasyRandomParameters todoParameters = new EasyRandomParameters()
-                .randomize(updateId, new LongRangeRandomizer(1L, 100L))
-                .randomize(updateState, new StringRandomizer());
+                .randomize(ID, IS_VALID_ID)
+                .randomize(STATE, IS_INVALID_STATE);
 
         EasyRandom generator = new EasyRandom(todoParameters);
         assertThrows(ConstraintViolationException.class, () -> todoController.updateTodo(generator.nextObject(UpdateTodoRequest.class)));
     }
-
 }

--- a/src/test/java/kr/rogarithm/todos/domain/todo/integration/TodoIntegrationTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/integration/TodoIntegrationTest.java
@@ -4,13 +4,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Random;
 import java.util.function.Predicate;
 import javax.validation.ConstraintViolationException;
 import kr.rogarithm.todos.domain.todo.controller.TodoController;
 import kr.rogarithm.todos.domain.todo.dto.AddTodoRequest;
+import kr.rogarithm.todos.domain.todo.dto.UpdateTodoRequest;
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 import org.jeasy.random.FieldPredicates;
+import org.jeasy.random.randomizers.range.LongRangeRandomizer;
+import org.jeasy.random.randomizers.text.StringRandomizer;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -66,4 +71,72 @@ public class TodoIntegrationTest {
             todoController.getTodos(state, size);
         }
     }
+
+    @DisplayName("id 필드가 유효하지 않은 할 일 수정 요청 시 실패")
+    @Test
+    public void updateTodoFailWhenInvalidIdParameter() {
+
+        Predicate<Field> updateId = FieldPredicates.named("id")
+                                                   .and(FieldPredicates.ofType(Long.class))
+                                                   .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+        Predicate<Field> updateState = FieldPredicates.named("state")
+                                                      .and(FieldPredicates.ofType(String.class))
+                                                      .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+        Predicate<Field> updateName = FieldPredicates.named("name")
+                                                     .and(FieldPredicates.ofType(String.class))
+                                                     .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+
+        EasyRandomParameters todoParameters = new EasyRandomParameters()
+                .randomize(updateId, new LongRangeRandomizer(-100L, 0L))
+                .randomize(updateState, () -> List.of("INCOMPLETE", "COMPLETE").get(new Random().nextInt(1)));
+
+        EasyRandom generator = new EasyRandom(todoParameters);
+        assertThrows(ConstraintViolationException.class, () -> todoController.updateTodo(generator.nextObject(UpdateTodoRequest.class)));
+    }
+
+    @DisplayName("name 필드가 유효하지 않은 할 일 수정 요청 시 실패")
+    @Test
+    public void updateTodoFailWhenInvalidParameter() {
+
+        Predicate<Field> updateId = FieldPredicates.named("id")
+                                                   .and(FieldPredicates.ofType(Long.class))
+                                                   .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+        Predicate<Field> updateState = FieldPredicates.named("state")
+                                                      .and(FieldPredicates.ofType(String.class))
+                                                      .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+        Predicate<Field> updateName = FieldPredicates.named("name")
+                                                     .and(FieldPredicates.ofType(String.class))
+                                                     .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+
+        EasyRandomParameters todoParameters = new EasyRandomParameters()
+                .randomize(updateId, new LongRangeRandomizer(1L, 100L))
+                .randomize(updateName, () -> "")
+                .randomize(updateState, () -> List.of("INCOMPLETE", "COMPLETE").get(new Random().nextInt(1)));
+
+        EasyRandom generator = new EasyRandom(todoParameters);
+        assertThrows(ConstraintViolationException.class, () -> todoController.updateTodo(generator.nextObject(UpdateTodoRequest.class)));
+    }
+
+    @DisplayName("state 필드가 유효하지 않은 할 일 수정 요청 시 실패")
+    @Test
+    public void updateTodoFailWhenInvalidStateParameter() {
+
+        Predicate<Field> updateId = FieldPredicates.named("id")
+                                                 .and(FieldPredicates.ofType(Long.class))
+                                                 .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+        Predicate<Field> updateState = FieldPredicates.named("state")
+                                                    .and(FieldPredicates.ofType(String.class))
+                                                    .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+        Predicate<Field> updateName = FieldPredicates.named("name")
+                                                    .and(FieldPredicates.ofType(String.class))
+                                                    .and(FieldPredicates.inClass(UpdateTodoRequest.class));
+
+        EasyRandomParameters todoParameters = new EasyRandomParameters()
+                .randomize(updateId, new LongRangeRandomizer(1L, 100L))
+                .randomize(updateState, new StringRandomizer());
+
+        EasyRandom generator = new EasyRandom(todoParameters);
+        assertThrows(ConstraintViolationException.class, () -> todoController.updateTodo(generator.nextObject(UpdateTodoRequest.class)));
+    }
+
 }

--- a/src/test/java/kr/rogarithm/todos/domain/todo/integration/TodoIntegrationTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/integration/TodoIntegrationTest.java
@@ -12,24 +12,55 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Random;
 import java.util.function.Predicate;
 import javax.validation.ConstraintViolationException;
 import kr.rogarithm.todos.domain.todo.controller.TodoController;
+import kr.rogarithm.todos.domain.todo.dao.TodoMapper;
+import kr.rogarithm.todos.domain.todo.domain.Todo;
 import kr.rogarithm.todos.domain.todo.dto.AddTodoRequest;
 import kr.rogarithm.todos.domain.todo.dto.UpdateTodoRequest;
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 import org.jeasy.random.FieldPredicates;
+import org.jeasy.random.randomizers.range.LongRangeRandomizer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
 
+@Sql({"/schema.sql"})
 @SpringBootTest
 public class TodoIntegrationTest {
 
     @Autowired
     TodoController todoController;
+
+    @Autowired
+    TodoMapper todoMapper;
+
+    @BeforeEach
+    public void setUp() {
+
+        Predicate<Field> todoId = FieldPredicates.named("id")
+                .and(FieldPredicates.ofType(Long.class))
+                .and(FieldPredicates.inClass(Todo.class));
+        Predicate<Field> todoState = FieldPredicates.named("state")
+                .and(FieldPredicates.ofType(String.class))
+                .and(FieldPredicates.inClass(Todo.class));
+        EasyRandomParameters todoParameters = new EasyRandomParameters()
+                .randomize(todoId, new LongRangeRandomizer(1L, 100L))
+                .randomize(todoState, () -> List.of("INCOMPLETE", "COMPLETE").get(new Random().nextInt(1)));
+
+        EasyRandom generator = new EasyRandom(todoParameters);
+
+        for (int i=0; i<10; i++) {
+            Todo todo = generator.nextObject(Todo.class);
+            todoMapper.insertTodo(todo);
+        }
+    }
 
     @Test
     public void addTodoFailWhenRequestNotSatisfyConstraint() {

--- a/src/test/java/kr/rogarithm/todos/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/service/TodoServiceTest.java
@@ -15,12 +15,15 @@ import kr.rogarithm.todos.domain.todo.dao.TodoMapper;
 import kr.rogarithm.todos.domain.todo.domain.Todo;
 import kr.rogarithm.todos.domain.todo.dto.AddTodoRequest;
 import kr.rogarithm.todos.domain.todo.dto.TodoResponse;
+import kr.rogarithm.todos.domain.todo.dto.UpdateTodoRequest;
 import kr.rogarithm.todos.domain.todo.exception.TodoItemNotFoundException;
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 import org.jeasy.random.FieldPredicates;
 import org.jeasy.random.randomizers.number.LongRandomizer;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -39,6 +42,8 @@ class TodoServiceTest {
     EasyRandom generator;
 
     EasyRandomParameters todoParameters;
+
+    UpdateTodoRequest updateTodoRequest;
 
     Long id;
 
@@ -59,6 +64,7 @@ class TodoServiceTest {
         generator = new EasyRandom(todoParameters);
         id = generator.nextObject(Long.class);
         size = generator.nextLong(1, 10);
+        updateTodoRequest = generator.nextObject(UpdateTodoRequest.class);
     }
 
     @Test
@@ -175,5 +181,31 @@ class TodoServiceTest {
         }
         todoService.getTodos(state, size);
         verify(todoMapper).selectTodos(state, size);
+    }
+
+    @Test
+    @DisplayName("할 일 업데이트 성공")
+    public void updateTodoSuccess() {
+
+        //when
+        when(todoMapper.selectTodoById(any(Long.class))).thenReturn(generator.nextObject(Todo.class));
+        when(todoMapper.updateTodo(any(Todo.class))).thenReturn(1);
+
+        //then
+        todoService.updateTodo(updateTodoRequest);
+        verify(todoMapper).selectTodoById(any(Long.class));
+        verify(todoMapper).updateTodo(any(Todo.class));
+    }
+
+    @Test
+    @DisplayName("전에 등록했던 할 일이 아니라면 업데이트에 실패")
+    public void updateTodoFailWhenTodoNotAddedBefore() {
+
+        //when
+        when(todoMapper.selectTodoById(any(Long.class))).thenReturn(null);
+
+        //then
+        Assertions.assertThrows(TodoItemNotFoundException.class, () -> todoService.updateTodo(updateTodoRequest));
+        verify(todoMapper).selectTodoById(any(Long.class));
     }
 }

--- a/src/test/java/learning/easyrandom/EasyRandomTest.java
+++ b/src/test/java/learning/easyrandom/EasyRandomTest.java
@@ -1,0 +1,55 @@
+package learning.easyrandom;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import org.assertj.core.api.Assertions;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.jeasy.random.FieldPredicates;
+import org.jeasy.random.randomizers.range.LongRangeRandomizer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class EasyRandomTest {
+
+    EasyRandom generator;
+
+    List<FakeTodo> todos;
+
+    @BeforeEach
+    public void setUp() {
+
+        Predicate<Field> todoId = FieldPredicates.named("id")
+                                                 .and(FieldPredicates.ofType(Long.class))
+                                                 .and(FieldPredicates.inClass(FakeTodo.class));
+        EasyRandomParameters todoParameters = new EasyRandomParameters()
+                .randomize(todoId, new LongRangeRandomizer(1L, 100L));
+        generator = new EasyRandom(todoParameters);
+    }
+
+    @DisplayName("id는 양수이기만 하면 된다")
+    @Test
+    public void idIsPositive() {
+
+        todos = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            todos.add(generator.nextObject(FakeTodo.class));
+        }
+
+        for (int i = 0; i < 100; i++) {
+            Assertions.assertThat(todos.get(i).getId()).isGreaterThan(-1L);
+        }
+    }
+
+    private static class FakeTodo {
+
+        private Long id;
+
+        public Long getId() {
+            return id;
+        }
+    }
+}


### PR DESCRIPTION
#### 작업 내용
- 할 일 하나를 수정하는 API를 구현한다
- 통합/E2E 테스트에서 데이터 추가, 수정으로 인해 다른 테스트가 깨졌다.
  - 통합 테스트에선 data.sql 쓰지 않고 DAO에 쿼리해서 테스트 데이터 준비하도록 바꿨다.
  - E2E 테스트에서도 이 방식이 괜찮은지 판단이 안서서, E2E에서만 data.sql로 테스트용 데이터 준비하도록 했다.
  - 수정하고 보니 코드가 번잡해져서 더 깔끔한 방법을 고민해봐야겠다.
- 반복되는 EasyRandomParameter을 클래스로 만들었다. 여기도 코드가 번잡해져서 더 깔끔한 방법을 고민해봐야겠다.

#### 연관 이슈(ex. #x)
- #4 