### PR TITLE
해당 API에 토큰 기반 Authorization을 적용한다

### DIFF
--- a/src/main/java/kr/rogarithm/todos/domain/auth/controller/AuthController.java
+++ b/src/main/java/kr/rogarithm/todos/domain/auth/controller/AuthController.java
@@ -36,6 +36,7 @@ public class AuthController {
                                               .build();
 
         response.setHeader("Set-Cookie", cookie.toString());
+        response.setHeader("Authorization", "Bearer " + tokens.getAccessToken());
 
         return ResponseEntity.status(HttpStatus.OK)
                              .body(LoginResponse.builder()

--- a/src/main/java/kr/rogarithm/todos/domain/verify/dto/VerifyResponse.java
+++ b/src/main/java/kr/rogarithm/todos/domain/verify/dto/VerifyResponse.java
@@ -1,11 +1,13 @@
 package kr.rogarithm.todos.domain.verify.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class VerifyResponse {
 
     private Boolean verify;
+
+    public VerifyResponse(Boolean verify) {
+        this.verify = verify;
+    }
 }

--- a/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,87 @@
+package kr.rogarithm.todos.global.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import java.io.IOException;
+import java.util.List;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtAuthenticationManager jwtAuthenticationManager;
+
+    private final List<String> excludedPaths = List.of(
+            "/auth/login", "/verify/account", "/verify/crn", "/verify/nickname", "/user"
+    );
+
+    public JwtAuthenticationFilter(JwtAuthenticationManager jwtAuthenticationManager) {
+        this.jwtAuthenticationManager = jwtAuthenticationManager;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        if (excludedPaths.contains(request.getServletPath())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+
+            response.getWriter().println("{ \"message\": \"" + "인증을 위해 JWT 토큰이 필요합니다." + "\" }");
+
+            return;
+        }
+
+        String token = authHeader.substring("Bearer ".length());
+
+        try {
+            jwtAuthenticationManager.verifyToken(token);
+        } catch (ExpiredJwtException e) {
+
+            ObjectMapper mapper = new ObjectMapper();
+
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+
+            ResponseStatusException responseStatusException = new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다.");
+
+            mapper.writeValue(response.getWriter(), responseStatusException);
+
+        } catch (JwtException e) {
+
+            ObjectMapper mapper = new ObjectMapper();
+
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+
+            ResponseStatusException responseStatusException = new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED, "잘못된 토큰 형식입니다.");
+
+            mapper.writeValue(response.getWriter(), responseStatusException);
+
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilter.java
@@ -30,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        if (excludedPaths.contains(request.getRequestURI())) {
+        if (excludedPaths.contains(request.getServletPath())) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package kr.rogarithm.todos.global.auth;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import java.io.IOException;
@@ -13,7 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.web.server.ResponseStatusException;
 
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -66,17 +64,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         } catch (JwtException e) {
 
-            ObjectMapper mapper = new ObjectMapper();
-
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setCharacterEncoding("UTF-8");
 
-            ResponseStatusException responseStatusException = new ResponseStatusException(
-                    HttpStatus.UNAUTHORIZED, "잘못된 토큰 형식입니다.");
+            response.getWriter().println("{ \"message\": \"" + "잘못된 토큰 형식입니다." + "\" }");
 
-            mapper.writeValue(response.getWriter(), responseStatusException);
-
+            return;
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilter.java
@@ -56,16 +56,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             jwtAuthenticationManager.verifyToken(token);
         } catch (ExpiredJwtException e) {
 
-            ObjectMapper mapper = new ObjectMapper();
-
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setCharacterEncoding("UTF-8");
 
-            ResponseStatusException responseStatusException = new ResponseStatusException(
-                    HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다.");
+            response.getWriter().println("{ \"message\": \"" + "토큰이 만료되었습니다." + "\" }");
 
-            mapper.writeValue(response.getWriter(), responseStatusException);
+            return;
 
         } catch (JwtException e) {
 

--- a/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilter.java
@@ -30,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        if (excludedPaths.contains(request.getServletPath())) {
+        if (excludedPaths.contains(request.getRequestURI())) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationManager.java
+++ b/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationManager.java
@@ -15,6 +15,9 @@ public class JwtAuthenticationManager {
 
     private static final String secretKey = "TodosAppSecretLengthIsMoreThan256";
 
+    public JwtAuthenticationManager() {
+    }
+
     public Claims verifyToken(String token) {
         Claims claims = Jwts.parserBuilder()
                           .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))

--- a/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationManager.java
+++ b/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationManager.java
@@ -1,6 +1,7 @@
 package kr.rogarithm.todos.global.auth;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -15,11 +16,17 @@ public class JwtAuthenticationManager {
     private static final String secretKey = "TodosAppSecretLengthIsMoreThan256";
 
     public Claims verifyToken(String token) {
-        return Jwts.parserBuilder()
-                   .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                   .build()
-                   .parseClaimsJws(token)
-                   .getBody();
+        Claims claims = Jwts.parserBuilder()
+                          .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                          .build()
+                          .parseClaimsJws(token)
+                          .getBody();
+
+        if (claims.getExpiration().getTime() < System.currentTimeMillis()) {
+            throw new ExpiredJwtException(null, null, "Token has expired");
+        }
+
+        return claims;
     }
 
     public String getUserIdByToken(String token) {

--- a/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationManager.java
+++ b/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationManager.java
@@ -1,0 +1,52 @@
+package kr.rogarithm.todos.global.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationManager {
+
+    private static final String secretKey = "TodosAppSecretLengthIsMoreThan256";
+
+    public Claims verifyToken(String token) {
+        return Jwts.parserBuilder()
+                   .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                   .build()
+                   .parseClaimsJws(token)
+                   .getBody();
+    }
+
+    public String getUserIdByToken(String token) {
+        return getBodyByToken(token).getSubject();
+    }
+
+    public long getExpirationDayByToken(String token) {
+        long now = new Date(System.currentTimeMillis()).getTime();
+        long expiration = getExpirationByToken(token).getTime();
+
+        return TimeUnit.DAYS.convert((expiration - now), TimeUnit.MILLISECONDS);
+    }
+
+    public Date getExpirationByToken(String token) {
+        return getBodyByToken(token).getExpiration();
+    }
+
+    private Key getSecretKey() {
+        return Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    private Claims getBodyByToken(String token) throws JwtException {
+        return Jwts
+                .parserBuilder()
+                .setSigningKey(getSecretKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationManager.java
+++ b/src/main/java/kr/rogarithm/todos/global/auth/JwtAuthenticationManager.java
@@ -2,12 +2,8 @@ package kr.rogarithm.todos.global.auth;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import java.security.Key;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -30,33 +26,5 @@ public class JwtAuthenticationManager {
         }
 
         return claims;
-    }
-
-    public String getUserIdByToken(String token) {
-        return getBodyByToken(token).getSubject();
-    }
-
-    public long getExpirationDayByToken(String token) {
-        long now = new Date(System.currentTimeMillis()).getTime();
-        long expiration = getExpirationByToken(token).getTime();
-
-        return TimeUnit.DAYS.convert((expiration - now), TimeUnit.MILLISECONDS);
-    }
-
-    public Date getExpirationByToken(String token) {
-        return getBodyByToken(token).getExpiration();
-    }
-
-    private Key getSecretKey() {
-        return Keys.hmacShaKeyFor(secretKey.getBytes());
-    }
-
-    private Claims getBodyByToken(String token) throws JwtException {
-        return Jwts
-                .parserBuilder()
-                .setSigningKey(getSecretKey())
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
     }
 }

--- a/src/test/java/kr/rogarithm/todos/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/auth/controller/AuthControllerTest.java
@@ -119,6 +119,31 @@ class AuthControllerTest {
     }
 
     @Test
+    public void accessTokenShouldBeStoredInAuthHeaderWhenJoinedUserLogin() throws Exception {
+
+        //when
+        when(authService.loginUser(any(LoginRequest.class))).thenReturn(tokens);
+
+        String content = objectMapper.writeValueAsString(validRequest);
+
+        //then
+        MvcResult mvcResult = mockMvc.perform(post("/auth/login")
+                                             .content(content)
+                                             .contentType(MediaType.APPLICATION_JSON)
+                                             .accept(MediaType.APPLICATION_JSON))
+                                     .andDo(print())
+                                     .andExpect(status().isOk())
+                                     .andReturn();
+
+        MockHttpServletResponse servletResponse = mvcResult.getResponse();
+
+        String authorizationHeader = servletResponse.getHeader("Authorization");
+        assertThat(authorizationHeader).isEqualTo("Bearer " + accessToken);
+
+        verify(authService).loginUser(any(LoginRequest.class));
+    }
+
+    @Test
     public void refreshTokenShouldBeStoredInCookieWhenJoinedUserLogin() throws Exception {
 
         //when

--- a/src/test/java/kr/rogarithm/todos/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/auth/controller/AuthControllerTest.java
@@ -55,39 +55,47 @@ class AuthControllerTest {
 
     LoginRequest request;
 
+    String accessToken;
+
+    String refreshToken;
+
+    Token tokens;
+
     @BeforeEach
     public void setUp() {
         generator = new EasyRandom();
         request = generator.nextObject(LoginRequest.class);
+
+        Date now = new Date();
+
+        accessToken = Jwts.builder()
+                          .setSubject(request.getAccount())
+                          .setIssuedAt(now)
+                          .signWith(Keys.hmacShaKeyFor("TodosAppSecretLengthIsMoreThan256".getBytes()),
+                                  SignatureAlgorithm.HS256)
+                          .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                          .setIssuer("todos.com")
+                          .setExpiration(new Date(now.getTime() + Duration.ofDays(1).toMillis()))
+                          .compact();
+
+        refreshToken = Jwts.builder()
+                           .setSubject(request.getAccount())
+                           .setIssuedAt(now)
+                           .signWith(Keys.hmacShaKeyFor("TodosAppSecretLengthIsMoreThan256".getBytes()),
+                                   SignatureAlgorithm.HS256)
+                           .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                           .setIssuer("todos.com")
+                           .setExpiration(new Date(now.getTime() + Duration.ofDays(30).toMillis()))
+                           .compact();
+
+        tokens = Token.builder()
+                      .accessToken(accessToken)
+                      .refreshToken(refreshToken)
+                      .build();
     }
 
     @Test
     public void refreshTokenShouldBePublishedWhenJoinedUserLogin() throws Exception {
-
-        //given
-        Date now = new Date();
-        String accessToken = Jwts.builder()
-                                 .setSubject(request.getAccount())
-                                 .setIssuedAt(now)
-                                 .signWith(Keys.hmacShaKeyFor("TodosAppSecretLengthIsMoreThan256".getBytes()),
-                                         SignatureAlgorithm.HS256)
-                                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                                 .setIssuer("higher-x.com")
-                                 .setExpiration(new Date(now.getTime() + Duration.ofDays(1).toMillis()))
-                                 .compact();
-        String refreshToken = Jwts.builder()
-                                  .setSubject(request.getAccount())
-                                  .setIssuedAt(now)
-                                  .signWith(Keys.hmacShaKeyFor("TodosAppSecretLengthIsMoreThan256".getBytes()),
-                                          SignatureAlgorithm.HS256)
-                                  .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                                  .setIssuer("higher-x.com")
-                                  .setExpiration(new Date(now.getTime() + Duration.ofDays(30).toMillis()))
-                                  .compact();
-        Token tokens = Token.builder()
-                            .accessToken(accessToken)
-                            .refreshToken(refreshToken)
-                            .build();
 
         //when
         when(authService.loginUser(any(LoginRequest.class))).thenReturn(tokens);

--- a/src/test/java/kr/rogarithm/todos/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/auth/controller/AuthControllerTest.java
@@ -20,6 +20,7 @@ import kr.rogarithm.todos.domain.auth.dto.LoginRequest;
 import kr.rogarithm.todos.domain.auth.exception.AuthenticationFailedException;
 import kr.rogarithm.todos.domain.auth.model.Token;
 import kr.rogarithm.todos.domain.auth.service.AuthService;
+import kr.rogarithm.todos.global.auth.JwtAuthenticationFilter;
 import kr.rogarithm.todos.global.auth.JwtGenerator;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,12 +29,20 @@ import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-@WebMvcTest(controllers = AuthController.class)
+@WebMvcTest(
+        controllers = AuthController.class,
+        excludeFilters =
+        @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = JwtAuthenticationFilter.class)
+)
 class AuthControllerTest {
 
     @Autowired
@@ -97,7 +106,7 @@ class AuthControllerTest {
         //when
         when(authService.loginUser(any(LoginRequest.class))).thenReturn(tokens);
 
-        String content = objectMapper.writeValueAsString(validRequest);
+        String content = objectMapper.writeValueAsString(request);
 
         //then
         MvcResult mvcResult = mockMvc.perform(post("/auth/login")
@@ -124,7 +133,7 @@ class AuthControllerTest {
         //when
         when(authService.loginUser(any(LoginRequest.class))).thenReturn(tokens);
 
-        String content = objectMapper.writeValueAsString(validRequest);
+        String content = objectMapper.writeValueAsString(request);
 
         //then
         MvcResult mvcResult = mockMvc.perform(post("/auth/login")

--- a/src/test/java/kr/rogarithm/todos/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/auth/controller/AuthControllerTest.java
@@ -67,7 +67,6 @@ class AuthControllerTest {
         request = generator.nextObject(LoginRequest.class);
 
         Date now = new Date();
-
         accessToken = Jwts.builder()
                           .setSubject(request.getAccount())
                           .setIssuedAt(now)
@@ -77,7 +76,6 @@ class AuthControllerTest {
                           .setIssuer("todos.com")
                           .setExpiration(new Date(now.getTime() + Duration.ofDays(1).toMillis()))
                           .compact();
-
         refreshToken = Jwts.builder()
                            .setSubject(request.getAccount())
                            .setIssuedAt(now)
@@ -87,7 +85,6 @@ class AuthControllerTest {
                            .setIssuer("todos.com")
                            .setExpiration(new Date(now.getTime() + Duration.ofDays(30).toMillis()))
                            .compact();
-
         tokens = Token.builder()
                       .accessToken(accessToken)
                       .refreshToken(refreshToken)

--- a/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
@@ -34,10 +34,10 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(
-        controllers = TodoController.class,
-        excludeFilters = @ComponentScan.Filter(
-                type = FilterType.ASSIGNABLE_TYPE,
-                classes = JwtAuthenticationFilter.class)
+    controllers = TodoController.class,
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE,
+        classes = JwtAuthenticationFilter.class)
 )
 class TodoControllerTest {
 
@@ -80,8 +80,8 @@ class TodoControllerTest {
 
         //then
         this.mockMvc.perform(get("/todo/{todoId}", id))
-                    .andDo(print())
-                    .andExpect(status().isNotFound());
+            .andDo(print())
+            .andExpect(status().isNotFound());
 
         verify(todoService).getTodoById(id);
     }
@@ -94,8 +94,8 @@ class TodoControllerTest {
 
         //then
         this.mockMvc.perform(get("/todo/{todoId}", id))
-                    .andDo(print())
-                    .andExpect(status().isOk());
+            .andDo(print())
+            .andExpect(status().isOk());
 
         verify(todoService).getTodoById(id);
     }
@@ -111,11 +111,11 @@ class TodoControllerTest {
 
         //then
         mockMvc.perform(post("/todo")
-                       .content(content)
-                       .contentType(MediaType.APPLICATION_JSON)
-                       .accept(MediaType.APPLICATION_JSON))
-               .andDo(print())
-               .andExpect(status().isOk());
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk());
 
         verify(todoService).saveTodo(addTodoRequest);
     }
@@ -127,31 +127,31 @@ class TodoControllerTest {
         Long size = 2L;
         String state = "ALL";
         TodoResponse todo1 = TodoResponse.builder()
-                                         .id(1L)
-                                         .name("커피 원두 구입")
-                                         .description("디벨로핑룸 가서 커피 원두 사기")
-                                         .state("COMPLETE")
-                                         .build();
+            .id(1L)
+            .name("커피 원두 구입")
+            .description("디벨로핑룸 가서 커피 원두 사기")
+            .state("COMPLETE")
+            .build();
         TodoResponse todo2 = TodoResponse.builder()
-                                         .id(2L)
-                                         .name("회덮밥 사오기")
-                                         .description("바다회 사랑 가서 회덮밥 포장해오기")
-                                         .state("INCOMPLETE")
-                                         .build();
+            .id(2L)
+            .name("회덮밥 사오기")
+            .description("바다회 사랑 가서 회덮밥 포장해오기")
+            .state("INCOMPLETE")
+            .build();
 
         //when
         when(todoService.getTodos(state, size)).thenReturn(List.of(todo1, todo2));
 
         //then
         mockMvc.perform(get("/todo")
-                       .queryParam("state", state)
-                       .queryParam("size", size.toString()))
-               .andDo(print())
-               .andExpect(jsonPath("$[0].id").value("1"))
-               .andExpect(jsonPath("$[0].name").value("커피 원두 구입"))
-               .andExpect(jsonPath("$[1].id").value("2"))
-               .andExpect(jsonPath("$[1].name").value("회덮밥 사오기"))
-               .andExpect(status().isOk());
+                .queryParam("state", state)
+                .queryParam("size", size.toString()))
+            .andDo(print())
+            .andExpect(jsonPath("$[0].id").value("1"))
+            .andExpect(jsonPath("$[0].name").value("커피 원두 구입"))
+            .andExpect(jsonPath("$[1].id").value("2"))
+            .andExpect(jsonPath("$[1].name").value("회덮밥 사오기"))
+            .andExpect(status().isOk());
 
         verify(todoService).getTodos(state, size);
     }
@@ -163,28 +163,28 @@ class TodoControllerTest {
         Long size = 1L;
         String state = "COMPLETE";
         TodoResponse todo1 = TodoResponse.builder()
-                                         .id(2L)
-                                         .name("회덮밥 사오기")
-                                         .description("바다회 사랑 가서 회덮밥 포장해오기")
-                                         .state("COMPLETE")
-                                         .build();
+            .id(2L)
+            .name("회덮밥 사오기")
+            .description("바다회 사랑 가서 회덮밥 포장해오기")
+            .state("COMPLETE")
+            .build();
         TodoResponse todo2 = TodoResponse.builder()
-                                         .id(2L)
-                                         .name("회덮밥 사오기")
-                                         .description("바다회 사랑 가서 회덮밥 포장해오기")
-                                         .state("INCOMPLETE")
-                                         .build();
+            .id(2L)
+            .name("회덮밥 사오기")
+            .description("바다회 사랑 가서 회덮밥 포장해오기")
+            .state("INCOMPLETE")
+            .build();
 
         //when
         when(todoService.getTodos(state, size)).thenReturn(List.of(todo1));
 
         //then
         mockMvc.perform(get("/todo")
-                       .queryParam("state", state)
-                       .queryParam("size", size.toString()))
-               .andDo(print())
-               .andExpect(jsonPath("$[0].state").value("COMPLETE"))
-               .andExpect(status().isOk());
+                .queryParam("state", state)
+                .queryParam("size", size.toString()))
+            .andDo(print())
+            .andExpect(jsonPath("$[0].state").value("COMPLETE"))
+            .andExpect(status().isOk());
 
         verify(todoService).getTodos(state, size);
     }
@@ -196,28 +196,28 @@ class TodoControllerTest {
         Long size = 1L;
         String state = "INCOMPLETE";
         TodoResponse todo1 = TodoResponse.builder()
-                                         .id(2L)
-                                         .name("회덮밥 사오기")
-                                         .description("바다회 사랑 가서 회덮밥 포장해오기")
-                                         .state("COMPLETE")
-                                         .build();
+            .id(2L)
+            .name("회덮밥 사오기")
+            .description("바다회 사랑 가서 회덮밥 포장해오기")
+            .state("COMPLETE")
+            .build();
         TodoResponse todo2 = TodoResponse.builder()
-                                         .id(2L)
-                                         .name("회덮밥 사오기")
-                                         .description("바다회 사랑 가서 회덮밥 포장해오기")
-                                         .state("INCOMPLETE")
-                                         .build();
+            .id(2L)
+            .name("회덮밥 사오기")
+            .description("바다회 사랑 가서 회덮밥 포장해오기")
+            .state("INCOMPLETE")
+            .build();
 
         //when
         when(todoService.getTodos(state, size)).thenReturn(List.of(todo2));
 
         //then
         mockMvc.perform(get("/todo")
-                       .queryParam("state", state)
-                       .queryParam("size", size.toString()))
-               .andDo(print())
-               .andExpect(jsonPath("$[0].state").value("INCOMPLETE"))
-               .andExpect(status().isOk());
+                .queryParam("state", state)
+                .queryParam("size", size.toString()))
+            .andDo(print())
+            .andExpect(jsonPath("$[0].state").value("INCOMPLETE"))
+            .andExpect(status().isOk());
 
         verify(todoService).getTodos(state, size);
     }
@@ -234,11 +234,11 @@ class TodoControllerTest {
 
         //then
         mockMvc.perform(put("/todo")
-                       .content(content)
-                       .contentType(MediaType.APPLICATION_JSON)
-                       .accept(MediaType.APPLICATION_JSON))
-               .andDo(print())
-               .andExpect(status().isOk());
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk());
 
         verify(todoService).updateTodo(updateTodoRequest);
     }
@@ -255,11 +255,11 @@ class TodoControllerTest {
 
         //then
         mockMvc.perform(put("/todo")
-                       .content(content)
-                       .contentType(MediaType.APPLICATION_JSON)
-                       .accept(MediaType.APPLICATION_JSON))
-               .andDo(print())
-               .andExpect(status().isNotFound());
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isNotFound());
 
         verify(todoService).updateTodo(updateTodoRequest);
     }

--- a/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/todo/controller/TodoControllerTest.java
@@ -19,6 +19,7 @@ import kr.rogarithm.todos.domain.todo.dto.TodoResponse;
 import kr.rogarithm.todos.domain.todo.dto.UpdateTodoRequest;
 import kr.rogarithm.todos.domain.todo.exception.TodoItemNotFoundException;
 import kr.rogarithm.todos.domain.todo.service.TodoService;
+import kr.rogarithm.todos.global.auth.JwtAuthenticationFilter;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,10 +28,17 @@ import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = TodoController.class)
+@WebMvcTest(
+        controllers = TodoController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = JwtAuthenticationFilter.class)
+)
 class TodoControllerTest {
 
     @Autowired

--- a/src/test/java/kr/rogarithm/todos/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/user/controller/UserControllerTest.java
@@ -12,6 +12,7 @@ import kr.rogarithm.todos.domain.user.dto.JoinUserRequest;
 import kr.rogarithm.todos.domain.user.exception.DuplicateAccountException;
 import kr.rogarithm.todos.domain.user.exception.InvalidCompanyRegistrationNumberException;
 import kr.rogarithm.todos.domain.user.service.UserService;
+import kr.rogarithm.todos.global.auth.JwtAuthenticationFilter;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,10 +21,18 @@ import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = UserController.class)
+@WebMvcTest(
+        controllers = UserController.class,
+        excludeFilters =
+        @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = JwtAuthenticationFilter.class)
+)
 class UserControllerTest {
 
     @Autowired

--- a/src/test/java/kr/rogarithm/todos/domain/verify/controller/VerifyControllerTest.java
+++ b/src/test/java/kr/rogarithm/todos/domain/verify/controller/VerifyControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import kr.rogarithm.todos.domain.verify.dto.VerifyResponse;
 import kr.rogarithm.todos.domain.verify.exception.VerificationException;
 import kr.rogarithm.todos.domain.verify.service.VerifyService;
+import kr.rogarithm.todos.global.auth.JwtAuthenticationFilter;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,10 +19,18 @@ import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = VerifyController.class)
+@WebMvcTest(
+        controllers = VerifyController.class,
+        excludeFilters =
+        @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = JwtAuthenticationFilter.class)
+)
 class VerifyControllerTest {
 
     @Autowired

--- a/src/test/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilterTest.java
@@ -2,7 +2,6 @@ package kr.rogarithm.todos.global.auth;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -157,13 +156,19 @@ class JwtAuthenticationFilterTest {
 
         String content = objectMapper.writeValueAsString(validRequest);
 
+        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post("/auth/login")
+                                                                      .header("Authorization",
+                                                                              "Bearer " + "access-token")
+                                                                      .cookie(new Cookie("RefreshToken",
+                                                                              "refresh-token"));
+
         when(authService.loginUser(any(LoginRequest.class))).thenReturn(tokens);
 
-        this.mockMvc.perform(post("/auth/login")
-                                             .content(content)
-                                             .contentType(MediaType.APPLICATION_JSON)
-                                             .accept(MediaType.APPLICATION_JSON))
-                                     .andDo(print())
-                                     .andExpect(status().isOk());
+        this.mockMvc.perform(request
+                            .content(content)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk());
     }
 }

--- a/src/test/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilterTest.java
@@ -1,0 +1,45 @@
+package kr.rogarithm.todos.global.auth;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import javax.servlet.http.Cookie;
+import kr.rogarithm.todos.domain.todo.controller.TodoController;
+import kr.rogarithm.todos.domain.todo.service.TodoService;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(controllers = TodoController.class)
+class JwtAuthenticationFilterTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @InjectMocks
+    TodoController todoController;
+
+    @MockBean
+    TodoService todoService;
+
+    @MockBean
+    JwtAuthenticationManager jwtAuthenticationManager;
+
+    @Test
+    public void failWithUnauthorizedCodeWhenTokenIsNull() throws Exception {
+
+        Long todoId = 1L;
+
+        MockHttpServletRequestBuilder requestNoAuthHeader = MockMvcRequestBuilders.get("/todo/{todoId}", todoId)
+                                                                                  .cookie(new Cookie("RefreshToken", "refresh-token"));
+
+        this.mockMvc.perform(requestNoAuthHeader)
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilterTest.java
@@ -1,28 +1,46 @@
 package kr.rogarithm.todos.global.auth;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Header;
 import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.time.Duration;
+import java.util.Date;
 import javax.servlet.http.Cookie;
+import kr.rogarithm.todos.domain.auth.controller.AuthController;
+import kr.rogarithm.todos.domain.auth.dto.LoginRequest;
+import kr.rogarithm.todos.domain.auth.model.Token;
+import kr.rogarithm.todos.domain.auth.service.AuthService;
 import kr.rogarithm.todos.domain.todo.controller.TodoController;
 import kr.rogarithm.todos.domain.todo.service.TodoService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-@WebMvcTest(controllers = TodoController.class)
+@WebMvcTest(controllers = {TodoController.class, AuthController.class})
 class JwtAuthenticationFilterTest {
 
     @Autowired
     MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
 
     @InjectMocks
     TodoController todoController;
@@ -30,8 +48,53 @@ class JwtAuthenticationFilterTest {
     @MockBean
     TodoService todoService;
 
+    @InjectMocks
+    AuthController authController;
+
+    @MockBean
+    AuthService authService;
+
     @MockBean
     JwtAuthenticationManager jwtAuthenticationManager;
+
+    LoginRequest validRequest;
+
+    String accessToken;
+
+    String refreshToken;
+
+    Token tokens;
+
+    @BeforeEach
+    public void setUpGiven() {
+        validRequest = LoginRequest.builder()
+                                   .account("sehoongim")
+                                   .password("q1w2e3!")
+                                   .build();
+        Date now = new Date();
+        accessToken = Jwts.builder()
+                          .setSubject(validRequest.getAccount())
+                          .setIssuedAt(now)
+                          .signWith(Keys.hmacShaKeyFor("TodosAppSecretLengthIsMoreThan256".getBytes()),
+                                  SignatureAlgorithm.HS256)
+                          .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                          .setIssuer("higher-x.com")
+                          .setExpiration(new Date(now.getTime() + Duration.ofDays(1).toMillis()))
+                          .compact();
+        refreshToken = Jwts.builder()
+                           .setSubject(validRequest.getAccount())
+                           .setIssuedAt(now)
+                           .signWith(Keys.hmacShaKeyFor("TodosAppSecretLengthIsMoreThan256".getBytes()),
+                                   SignatureAlgorithm.HS256)
+                           .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                           .setIssuer("higher-x.com")
+                           .setExpiration(new Date(now.getTime() + Duration.ofDays(30).toMillis()))
+                           .compact();
+        tokens = Token.builder()
+                      .accessToken(accessToken)
+                      .refreshToken(refreshToken)
+                      .build();
+    }
 
     @Test
     public void failWithUnauthorizedCodeWhenNoAccessToken() throws Exception {
@@ -39,7 +102,8 @@ class JwtAuthenticationFilterTest {
         Long todoId = 1L;
 
         MockHttpServletRequestBuilder requestNoAuthHeader = MockMvcRequestBuilders.get("/todo/{todoId}", todoId)
-                                                                                  .cookie(new Cookie("RefreshToken", "refresh-token"));
+                                                                                  .cookie(new Cookie("RefreshToken",
+                                                                                          "refresh-token"));
 
         this.mockMvc.perform(requestNoAuthHeader)
                     .andDo(print())
@@ -54,8 +118,10 @@ class JwtAuthenticationFilterTest {
         when(jwtAuthenticationManager.verifyToken("access-token")).thenThrow(ExpiredJwtException.class);
 
         MockHttpServletRequestBuilder requestNoAuthHeader = MockMvcRequestBuilders.get("/todo/{todoId}", todoId)
-                                                                                  .header("Authorization", "Bearer "+ "access-token")
-                                                                                  .cookie(new Cookie("RefreshToken", "refresh-token"));
+                                                                                  .header("Authorization",
+                                                                                          "Bearer " + "access-token")
+                                                                                  .cookie(new Cookie("RefreshToken",
+                                                                                          "refresh-token"));
 
         this.mockMvc.perform(requestNoAuthHeader)
                     .andDo(print())
@@ -70,11 +136,34 @@ class JwtAuthenticationFilterTest {
         when(jwtAuthenticationManager.verifyToken("access-token-in-wrong-format")).thenThrow(JwtException.class);
 
         MockHttpServletRequestBuilder requestNoAuthHeader = MockMvcRequestBuilders.get("/todo/{todoId}", todoId)
-                                                                                  .header("Authorization", "Bearer "+ "access-token-in-wrong-format")
-                                                                                  .cookie(new Cookie("RefreshToken", "refresh-token"));
+                                                                                  .header("Authorization", "Bearer "
+                                                                                          + "access-token-in-wrong-format")
+                                                                                  .cookie(new Cookie("RefreshToken",
+                                                                                          "refresh-token"));
 
         this.mockMvc.perform(requestNoAuthHeader)
                     .andDo(print())
                     .andExpect(status().isUnauthorized());
+    }
+
+
+    @Test
+    public void bypassFilterWhenGivenApiNeedNoAuthorization() throws Exception {
+
+        LoginRequest validRequest = LoginRequest.builder()
+                                                .account("sehoongim")
+                                                .password("q1w2e3!")
+                                                .build();
+
+        String content = objectMapper.writeValueAsString(validRequest);
+
+        when(authService.loginUser(any(LoginRequest.class))).thenReturn(tokens);
+
+        this.mockMvc.perform(post("/auth/login")
+                                             .content(content)
+                                             .contentType(MediaType.APPLICATION_JSON)
+                                             .accept(MediaType.APPLICATION_JSON))
+                                     .andDo(print())
+                                     .andExpect(status().isOk());
     }
 }

--- a/src/test/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilterTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import javax.servlet.http.Cookie;
 import kr.rogarithm.todos.domain.todo.controller.TodoController;
 import kr.rogarithm.todos.domain.todo.service.TodoService;
@@ -54,6 +55,22 @@ class JwtAuthenticationFilterTest {
 
         MockHttpServletRequestBuilder requestNoAuthHeader = MockMvcRequestBuilders.get("/todo/{todoId}", todoId)
                                                                                   .header("Authorization", "Bearer "+ "access-token")
+                                                                                  .cookie(new Cookie("RefreshToken", "refresh-token"));
+
+        this.mockMvc.perform(requestNoAuthHeader)
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void failWithUnauthorizedCodeWhenTokenIsWrongFormat() throws Exception {
+
+        Long todoId = 1L;
+
+        when(jwtAuthenticationManager.verifyToken("access-token-in-wrong-format")).thenThrow(JwtException.class);
+
+        MockHttpServletRequestBuilder requestNoAuthHeader = MockMvcRequestBuilders.get("/todo/{todoId}", todoId)
+                                                                                  .header("Authorization", "Bearer "+ "access-token-in-wrong-format")
                                                                                   .cookie(new Cookie("RefreshToken", "refresh-token"));
 
         this.mockMvc.perform(requestNoAuthHeader)

--- a/src/test/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/kr/rogarithm/todos/global/auth/JwtAuthenticationFilterTest.java
@@ -100,9 +100,9 @@ class JwtAuthenticationFilterTest {
 
         Long todoId = 1L;
 
-        MockHttpServletRequestBuilder requestNoAuthHeader = MockMvcRequestBuilders.get("/todo/{todoId}", todoId)
-                                                                                  .cookie(new Cookie("RefreshToken",
-                                                                                          "refresh-token"));
+        MockHttpServletRequestBuilder requestNoAuthHeader =
+                MockMvcRequestBuilders.get("/todo/{todoId}", todoId)
+                                      .cookie(new Cookie("RefreshToken", "refresh-token"));
 
         this.mockMvc.perform(requestNoAuthHeader)
                     .andDo(print())
@@ -114,13 +114,14 @@ class JwtAuthenticationFilterTest {
 
         Long todoId = 1L;
 
-        when(jwtAuthenticationManager.verifyToken("access-token")).thenThrow(ExpiredJwtException.class);
+        when(jwtAuthenticationManager.verifyToken("access-token"))
+                .thenThrow(ExpiredJwtException.class);
 
-        MockHttpServletRequestBuilder requestNoAuthHeader = MockMvcRequestBuilders.get("/todo/{todoId}", todoId)
-                                                                                  .header("Authorization",
-                                                                                          "Bearer " + "access-token")
-                                                                                  .cookie(new Cookie("RefreshToken",
-                                                                                          "refresh-token"));
+        MockHttpServletRequestBuilder requestNoAuthHeader =
+                MockMvcRequestBuilders.get("/todo/{todoId}", todoId)
+                                      .header("Authorization",
+                                              "Bearer " + "access-token")
+                                      .cookie(new Cookie("RefreshToken", "refresh-token"));
 
         this.mockMvc.perform(requestNoAuthHeader)
                     .andDo(print())
@@ -132,13 +133,14 @@ class JwtAuthenticationFilterTest {
 
         Long todoId = 1L;
 
-        when(jwtAuthenticationManager.verifyToken("access-token-in-wrong-format")).thenThrow(JwtException.class);
+        when(jwtAuthenticationManager.verifyToken("access-token-in-wrong-format"))
+                .thenThrow(JwtException.class);
 
-        MockHttpServletRequestBuilder requestNoAuthHeader = MockMvcRequestBuilders.get("/todo/{todoId}", todoId)
-                                                                                  .header("Authorization", "Bearer "
-                                                                                          + "access-token-in-wrong-format")
-                                                                                  .cookie(new Cookie("RefreshToken",
-                                                                                          "refresh-token"));
+        MockHttpServletRequestBuilder requestNoAuthHeader =
+                MockMvcRequestBuilders.get("/todo/{todoId}", todoId)
+                                      .header("Authorization",
+                                              "Bearer " + "access-token-in-wrong-format")
+                                      .cookie(new Cookie("RefreshToken", "refresh-token"));
 
         this.mockMvc.perform(requestNoAuthHeader)
                     .andDo(print())
@@ -156,18 +158,16 @@ class JwtAuthenticationFilterTest {
 
         String content = objectMapper.writeValueAsString(validRequest);
 
-        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post("/auth/login")
-                                                                      .header("Authorization",
-                                                                              "Bearer " + "access-token")
-                                                                      .cookie(new Cookie("RefreshToken",
-                                                                              "refresh-token"));
+        MockHttpServletRequestBuilder request =
+                MockMvcRequestBuilders.post("/auth/login")
+                                      .header("Authorization", "Bearer " + "access-token")
+                                      .cookie(new Cookie("RefreshToken", "refresh-token"));
 
         when(authService.loginUser(any(LoginRequest.class))).thenReturn(tokens);
 
-        this.mockMvc.perform(request
-                            .content(content)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .accept(MediaType.APPLICATION_JSON))
+        this.mockMvc.perform(request.content(content)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .accept(MediaType.APPLICATION_JSON))
                     .andDo(print())
                     .andExpect(status().isOk());
     }

--- a/src/test/java/learning/jdk/StringTest.java
+++ b/src/test/java/learning/jdk/StringTest.java
@@ -1,0 +1,13 @@
+package learning.jdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class StringTest {
+
+    @Test
+    public void removeFirstNCharactersUsingSubstring() {
+        assertThat("Bearer access-token".substring("Bearer ".length())).isEqualTo("access-token");
+    }
+}


### PR DESCRIPTION
#### 작업 내용
- 스프링 필터와 JWT로 인증 기능을 구현한다.
- 현재 구현된 API 중 인증이 필요한 API에 인증 필터를 적용했다.
- 인증 필터 추가로 인해 깨지는 테스트를 통과하도록 고친다. 대부분은 필터를 테스트에 참여하지 않도록 해서
요청의 토큰 정보 소유 여부가 테스트 결과에 영향을 미치지 않도록 했다.
- E2E 테스트에서 필터에 의한 영향을 어떻게 처리하는지 고민했다.
  1) 이전 요청의 결과, 즉 로그인 요청에 의해 생성되어 응답에 포함되는 토큰과 같은 정보는 이후 요청에 포함되지 않는다.
  http request는 stateless하기 때문이다.
  2) 이런 정보를 다음 요청에 포함시키는 것은 서버가 아니라 클라이언트의 역할이다.
  3) 현재 Todo API의 E2E 테스트에서는 인증 필터가 참여한다. E2E 테스트는 애플리케이션의 전 과정을 확인해야 한다고
  생각하기 때문이다. 먼저 로그인을 요청하고, 이에 따라 만들어진 토큰 정보를 인증이 필요한 API 호출에 쓴다.
  4) i, ii를 고려했을 때 현재 E2E 방식처럼 확인하는 것은 서버에서 이전 요청의 결과를 저장하는 책임을 맡게 되어
  적절하지 않다고 보이고, 따라서 테스트 방식 개선이 필요해보인다.

#### 추가할 이슈
- EasyRandom 방식으로 테스트 데이터 변경 필요
- Todo API E2E 테스트 방식 개선 필요
- 테스트의 토큰 정보 생성 방식 개선하기
  - 하드코딩 방식인데, 만약 토큰을 만들 요청 내 정보가 바뀌게 되면 토큰 정보도
  그에 따라 바뀌어야할 테고, 결과적으로 테스트가 변화에 유연해지지 않게 될 것 같다.

#### 연관 이슈(ex. #x)
- #15 
